### PR TITLE
Update wirbelsturm to use newer AWS cli

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,20 +1,46 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    activemodel (4.1.4)
+      activesupport (= 4.1.4)
+      builder (~> 3.1)
+    activesupport (4.1.4)
+      i18n (~> 0.6, >= 0.6.9)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.1)
+      tzinfo (~> 1.1)
+    builder (3.2.2)
     facter (1.6.18)
+    faraday (0.9.0)
+      multipart-post (>= 1.2, < 3)
+    her (0.7.2)
+      activemodel (>= 3.0.0, < 4.2)
+      activesupport (>= 3.0.0, < 4.2)
+      faraday (>= 0.8, < 1.0)
+      multi_json (~> 1.7)
     hiera (1.0.0)
     highline (1.6.21)
+    i18n (0.6.11)
     json (1.8.1)
     librarian (0.1.2)
       highline
       thor (~> 0.15)
-    librarian-puppet (0.9.17)
-      json
+    librarian-puppet (1.3.1)
       librarian (>= 0.1.2)
+      puppet_forge
+    minitest (5.4.0)
+    multi_json (1.10.1)
+    multipart-post (2.0.0)
     puppet (3.0.1)
       facter (~> 1.6.11)
       hiera (~> 1.0.0)
+    puppet_forge (1.0.3)
+      her (~> 0.6)
     thor (0.19.1)
+    thread_safe (0.3.4)
+    tzinfo (1.2.1)
+      thread_safe (~> 0.1)
 
 PLATFORMS
   ruby

--- a/aws/aws-setup-security-group.sh
+++ b/aws/aws-setup-security-group.sh
@@ -20,43 +20,43 @@ warn "      for Wirbelsturm."
 warn
 
 puts "Creating '$SECURITY_GROUP' security group for Wirbelsturm..."
-ec2-create-group $SECURITY_GROUP -d "Wirbelsturm cluster (security policy v$VERSION)"
+aws ec2 create-security-group --group-name $SECURITY_GROUP --description "Wirbelsturm cluster (security policy v$VERSION)"
 if [ $? -ne 0 ]; then
   warn "Note: If you want to delete the security group you can do so with:"
   warn
-  warn "    $ ec2-delete-group $SECURITY_GROUP"
+  warn "    $ aws ec2 delete-security-group --group-name $SECURITY_GROUP"
   warn
   warn "DELETING A GROUP WILL DELETE ALL OF ITS RULES AND IS NOT REVERSIBLE."
   exit 1
 fi
 
 puts "Enable SSH access"
-ec2-authorize -P tcp -p 22 $SECURITY_GROUP || exit 1
+aws ec2 authorize-security-group-ingress --protocol tcp --port 22 --group-name $SECURITY_GROUP || exit 1
 
 puts "Enable access to Storm master"
 # 6627 (thrift/Nimbus)
 # 8080 (UI)
-ec2-authorize -P tcp -p 6627 $SECURITY_GROUP || exit 1
-ec2-authorize -P tcp -p 8080 $SECURITY_GROUP || exit 1
+aws ec2 authorize-security-group-ingress --protocol tcp --port 6627 --group-name $SECURITY_GROUP || exit 1
+aws ec2 authorize-security-group-ingress --protocol tcp --port 8080 --group-name $SECURITY_GROUP || exit 1
 
 puts "Enable access to Storm slaves"
 # 3772 (drpc), 3773 (drpc invocations)
 # 67xx supervisor ports
-ec2-authorize -P tcp -p 3772-3773 $SECURITY_GROUP || exit 1
-ec2-authorize -P tcp -p 6700-6799 $SECURITY_GROUP || exit 1
+aws ec2 authorize-security-group-ingress --protocol tcp --port 3772-3773 --group-name $SECURITY_GROUP || exit 1
+aws ec2 authorize-security-group-ingress --protocol tcp --port 6700-6799 --group-name $SECURITY_GROUP || exit 1
 
 puts "Enable access to Kafka"
-ec2-authorize -P tcp -p 9092 $SECURITY_GROUP || exit 1
+aws ec2 authorize-security-group-ingress --protocol tcp --port 9092 --group-name $SECURITY_GROUP || exit 1
 
 puts "Enable access to Zookeeper"
-ec2-authorize -P tcp -p 2181 $SECURITY_GROUP || exit 1
+aws ec2 authorize-security-group-ingress --protocol tcp --port 2181 --group-name $SECURITY_GROUP || exit 1
 
 puts "Enable access to Redis"
-ec2-authorize -P tcp -p 6379 $SECURITY_GROUP || exit 1
+aws ec2 authorize-security-group-ingress --protocol tcp --port 6379 --group-name $SECURITY_GROUP || exit 1
 
 puts "------------------------------------------------------------------------"
 puts "Summary of security group:"
-ec2-describe-group $SECURITY_GROUP
+aws ec2 describe-security-groups --group-names $SECURITY_GROUP
 puts "------------------------------------------------------------------------"
 
 success "You can now use the AWS security group '$SECURITY_GROUP' for your Wirbelsturm cluster."


### PR DESCRIPTION
This probably doesn't need to be merged, but the old homebrew version of AWS cli has been removed. This uses the latest [AWS cli](http://aws.amazon.com/cli/). This could at least be a reference for anyone else that wants to use the latest.
