### PR TITLE
Update the download link for Vagrant and bump the version number.

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,13 +304,13 @@ Preferably Mac OS X users should also:
 
 ### Install Vagrant
 
-* [Download version 1.6.3 of Vagrant](http://downloads.vagrantup.com/) for your OS and install accordingly.
+* [Download version 1.6.5 of Vagrant](http://www.vagrantup.com/downloads.html) for your OS and install accordingly.
 
 Verify the installation of Vagrant:
 
 ```shell
 $ vagrant -v
-Vagrant version 1.6.3
+Vagrant version 1.6.5
 ```
 
 **Note for Mac OS X users:** To uninstall Vagrant run the `uninstall.tool` script that is included in the `.dmg` file.


### PR DESCRIPTION
The existing download link for Vagrant only had versions up to 1.3.5, so I've updated it to the current link. Also the current version of Vagrant is now 1.6.5, instead of 1.6.3.
